### PR TITLE
Rework basic auth to only send credentials to the registry itself.

### DIFF
--- a/registry/basictransport.go
+++ b/registry/basictransport.go
@@ -2,17 +2,21 @@ package registry
 
 import (
 	"net/http"
+	"strings"
 )
 
 type BasicTransport struct {
 	Transport http.RoundTripper
+	URL       string
 	Username  string
 	Password  string
 }
 
 func (t *BasicTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if t.Username != "" || t.Password != "" {
-		req.SetBasicAuth(t.Username, t.Password)
+	if strings.HasPrefix(req.URL.String(), t.URL) {
+		if t.Username != "" || t.Password != "" {
+			req.SetBasicAuth(t.Username, t.Password)
+		}
 	}
 	resp, err := t.Transport.RoundTrip(req)
 	return resp, err

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -23,6 +23,7 @@ func New(registryUrl, username, password string) (*Registry, error) {
 	}
 	transport = &BasicTransport{
 		Transport: transport,
+		URL:       url,
 		Username:  username,
 		Password:  password,
 	}
@@ -58,7 +59,7 @@ func (r *Registry) Ping() error {
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		
+
 	}
 	return err
 }


### PR DESCRIPTION
Registry implementations that _redirect_ clients to other stores (such as S3)
should not cause those stores to be presented with registry credentials.