### PR TITLE
Replace basic auth with bearer

### DIFF
--- a/registry/tokentransport.go
+++ b/registry/tokentransport.go
@@ -69,7 +69,7 @@ func (t *TokenTransport) auth(authService *authService) (string, *http.Response,
 }
 
 func (t *TokenTransport) retry(req *http.Request, token string) (*http.Response, error) {
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	resp, err := t.Transport.RoundTrip(req)
 	return resp, err
 }


### PR DESCRIPTION
I found that this was necessary to get it to work with registry-1.docker.io.

Otherwise it sends two Authorization headers, one Basic and one Bearer, and I think the server only looks at the first.