### PR TITLE
Add method to retrieve the list of available repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ API, which may fail. Failures return non-`nil` err values.
 Authentication supports both HTTP Basic authentication and OAuth2 token
 negotiation.
 
+## Listing Repositories
+
+```go
+repositories, err := hub.Repositories()
+```
+
+The repositories will be returned as a slice of `string`s.
+
 ## Listing Tags
 
 Each Docker repository has a set of tags -- named images that can be downloaded.

--- a/registry/repositories.go
+++ b/registry/repositories.go
@@ -1,0 +1,17 @@
+package registry
+
+type repositoriesResponse struct {
+	Repositories []string `json:"repositories"`
+}
+
+func (registry *Registry) Repositories() ([]string, error) {
+	url := registry.url("/v2/_catalog")
+	registry.Logf("registry.repositories url=%s", url)
+
+	var response repositoriesResponse
+	if err := registry.getJson(url, &response); err != nil {
+		return nil, err
+	}
+
+	return response.Repositories, nil
+}


### PR DESCRIPTION
Retrieves a list of repositories from the `/v2/_catalog` endpoint.