### PR TITLE
Follow Link header in tags/list responses

### DIFF
--- a/registry/json.go
+++ b/registry/json.go
@@ -2,6 +2,13 @@ package registry
 
 import (
 	"encoding/json"
+	"errors"
+	"net/http"
+	"regexp"
+)
+
+var (
+	ErrNoMorePages = errors.New("No more pages")
 )
 
 func (registry *Registry) getJson(url string, response interface{}) error {
@@ -20,4 +27,42 @@ func (registry *Registry) getJson(url string, response interface{}) error {
 	}
 
 	return nil
+}
+
+// getPaginatedJson accepts a string and a pointer, and returns the
+// next page URL while updating pointed-to variable with a parsed JSON
+// value. When there are no more pages it returns `ErrNoMorePages`.
+func (registry *Registry) getPaginatedJson(url string, response interface{}) (string, error) {
+	resp, err := registry.Client.Get(url)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return "", err
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(response)
+	if err != nil {
+		return "", err
+	}
+	return getNextLink(resp)
+}
+
+var linkRE *regexp.Regexp = regexp.MustCompile(`^ *<?([^;>]+)>?(?:; *([a-z]+)="?([^";]*)"?)*$`)
+
+func getNextLink(resp *http.Response) (string, error) {
+	for _, link := range resp.Header[http.CanonicalHeaderKey("Link")] {
+		parts := linkRE.FindStringSubmatch(link)
+		if len(parts) < 4 {
+			continue
+		}
+		// We have a structure like []string{(whole match), URL, key, value, ...}
+		for i := 2; i < len(parts); i += 2 {
+			if parts[i] == "rel" && parts[i+1] == "next" {
+				return parts[1], nil
+			}
+		}
+	}
+	return "", ErrNoMorePages
 }

--- a/registry/repositories.go
+++ b/registry/repositories.go
@@ -4,14 +4,22 @@ type repositoriesResponse struct {
 	Repositories []string `json:"repositories"`
 }
 
-func (registry *Registry) Repositories() ([]string, error) {
+func (registry *Registry) Repositories() (repos []string, err error) {
 	url := registry.url("/v2/_catalog")
-	registry.Logf("registry.repositories url=%s", url)
 
 	var response repositoriesResponse
-	if err := registry.getJson(url, &response); err != nil {
-		return nil, err
+	for {
+		registry.Logf("registry.repositories url=%s", url)
+		url, err = registry.getPaginatedJson(url, &response)
+		switch err {
+		case ErrNoMorePages:
+			repos = append(repos, response.Repositories...)
+			return repos, nil
+		case nil:
+			repos = append(repos, response.Repositories...)
+			continue
+		default:
+			return nil, err
+		}
 	}
-
-	return response.Repositories, nil
 }

--- a/registry/tags.go
+++ b/registry/tags.go
@@ -4,14 +4,22 @@ type tagsResponse struct {
 	Tags []string `json:"tags"`
 }
 
-func (registry *Registry) Tags(repository string) ([]string, error) {
+func (registry *Registry) Tags(repository string) (tags []string, err error) {
 	url := registry.url("/v2/%s/tags/list", repository)
-	registry.Logf("registry.tags url=%s repository=%s", url, repository)
 
 	var response tagsResponse
-	if err := registry.getJson(url, &response); err != nil {
-		return nil, err
+	for {
+		registry.Logf("registry.tags url=%s repository=%s", url, repository)
+		url, err = registry.getPaginatedJson(url, &response)
+		switch err {
+		case ErrNoMorePages:
+			tags = append(tags, response.Tags...)
+			return tags, nil
+		case nil:
+			tags = append(tags, response.Tags...)
+			continue
+		default:
+			return nil, err
+		}
 	}
-
-	return response.Tags, nil
 }


### PR DESCRIPTION
In the Docker registry API v2 specification, the response to a list tags call may be paginated by the server. It does this using an RFC5988 `Link` header, with `rel=next`; no header means no more pages.

At least quay.io uses this mechanism to return pages of 50 tags at a time, though it gets the format slightly wrong (by missing the `<` and `>` around the URL).

This PR makes the `registry.Tags` method deal with pagination, by following the `Link` header when it's present. I've used a regexp to parse the Link header; it's not exactly correct, but probably good enough in practice.