### PR TITLE
Fix GCR support

### DIFF
--- a/registry/tokentransport.go
+++ b/registry/tokentransport.go
@@ -88,7 +88,9 @@ func (authService *authService) Request(username, password string) (*http.Reques
 
 	q := url.Query()
 	q.Set("service", authService.Service)
-	q.Set("scope", authService.Scope)
+	if authService.Scope != "" {
+		q.Set("scope", authService.Scope)
+	}
 	url.RawQuery = q.Encode()
 
 	request, err := http.NewRequest("GET", url.String(), nil)


### PR DESCRIPTION
This patch fixes Google Container Registry support.

- GCR return `401 Unauthorized` with no scopes when ping
- GCR reject auth with empty string scope