### PR TITLE
Only set scope if value is valid

### DIFF
--- a/registry/tokentransport.go
+++ b/registry/tokentransport.go
@@ -88,7 +88,9 @@ func (authService *authService) Request(username, password string) (*http.Reques
 
 	q := url.Query()
 	q.Set("service", authService.Service)
-	q.Set("scope", authService.Scope)
+	if authService.Scope != "" {
+		q.Set("scope", authService.Scope)
+	}
 	url.RawQuery = q.Encode()
 
 	request, err := http.NewRequest("GET", url.String(), nil)


### PR DESCRIPTION
gitlab docker do not work with this registry-client.
if i only set the scope if it is not empty it is working fine.


