### PR TITLE
Fixing partial url for quay.io

### DIFF
--- a/registry/json.go
+++ b/registry/json.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-       nurl "net/url"
+	nurl "net/url"
 	"regexp"
 )
 
@@ -44,22 +44,22 @@ func (registry *Registry) getPaginatedJson(url string, response interface{}) (st
 		return "", err
 	}
 
-       nextUri, err := getNextLink(resp)
-       if err != nil {
-               return "", err
-       }
+	nextUri, err := getNextLink(resp)
+	if err != nil {
+		return "", err
+	}
 
-       base, err := nurl.Parse(registry.URL)
-       if err != nil {
-               return "", err
-       }
+	base, err := nurl.Parse(registry.URL)
+	if err != nil {
+		return "", err
+	}
 
-       u, err := nurl.Parse(nextUri)
-       if err != nil {
-               return "", err
-       }
+	u, err := nurl.Parse(nextUri)
+	if err != nil {
+		return "", err
+	}
 
-       return base.ResolveReference(u).String(), nil
+	return base.ResolveReference(u).String(), nil
 }
 
 // Matches an RFC 5988 (https://tools.ietf.org/html/rfc5988#section-5)

--- a/registry/json.go
+++ b/registry/json.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+       nurl "net/url"
 	"regexp"
 )
 
@@ -42,7 +43,23 @@ func (registry *Registry) getPaginatedJson(url string, response interface{}) (st
 	if err != nil {
 		return "", err
 	}
-	return getNextLink(resp)
+
+       nextUri, err := getNextLink(resp)
+       if err != nil {
+               return "", err
+       }
+
+       base, err := nurl.Parse(registry.URL)
+       if err != nil {
+               return "", err
+       }
+
+       u, err := nurl.Parse(nextUri)
+       if err != nil {
+               return "", err
+       }
+
+       return base.ResolveReference(u).String(), nil
 }
 
 // Matches an RFC 5988 (https://tools.ietf.org/html/rfc5988#section-5)


### PR DESCRIPTION
Quay.io returns "next page" links like '/v2/....' vs including fully qualified URLs. This patch does the URL join with the registry URL to get a proper fully qualified URL