### PR TITLE
go-digest repository is moved.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ API](http://docs.docker.com/registry/spec/api/), for Go applications.
 ```go
 import (
     "github.com/heroku/docker-registry-client/registry"
-    "github.com/docker/distribution/digest"
+    "github.com/opencontainers/go-digest"
     "github.com/docker/distribution/manifest"
     "github.com/docker/libtrust"
 )


### PR DESCRIPTION
`github.com/docker/distribution/digest repository` is moved to `github.com/opencontainers/go-digest/blob/master/digest.go`.