### PR TITLE
feature: adding ability to delete image from digest to registry client

### DIFF
--- a/registry/deleteimagefromdigest.go
+++ b/registry/deleteimagefromdigest.go
@@ -1,0 +1,25 @@
+package registry
+
+import (
+	"net/http"
+)
+
+func (registry *Registry) DeleteImageFromDigest(repository string, digest string) error {
+	url := registry.url("/v2/%s/manifests/%s", repository, digest)
+	registry.Logf("registry.image.delete url=%s repository=%s reference=%s", url, repository, digest)
+
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := registry.Client.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adding the ability to delete an image using the digest. 
On the docker API, you can delete an image with DELETE /v2/<name>/manifests/<reference>

In this case, reference is the image digest.