### PR TITLE
Fix memory leak in TokenTransport

### DIFF
--- a/registry/tokentransport.go
+++ b/registry/tokentransport.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 )
@@ -19,6 +20,14 @@ func (t *TokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return resp, err
 	}
 	if authService := isTokenDemand(resp); authService != nil {
+		_, err := ioutil.ReadAll(resp.Body)
+		if err == nil {
+			err = resp.Body.Close()
+		}
+		if err != nil {
+			return nil, fmt.Errorf("http: failed to close token demand response (status=%v, err=%q)", resp.StatusCode, err)
+		}
+
 		resp, err = t.authAndRetry(authService, req)
 	}
 	return resp, err


### PR DESCRIPTION
Close token-demand response before making auth-and-retry.

Unclosed responses lead to unclosed sockets and to memory leaks in long running apps:

```
...
lrwx------ 1 root root 64 Mar 12 20:16 11 -> socket:[3213896]
lrwx------ 1 root root 64 Mar 12 20:16 110 -> socket:[3238100]
lrwx------ 1 root root 64 Mar 12 20:16 111 -> socket:[3238973]
lrwx------ 1 root root 64 Mar 12 20:16 112 -> socket:[3238317]
lrwx------ 1 root root 64 Mar 12 20:16 113 -> socket:[3239210]
lrwx------ 1 root root 64 Mar 12 20:16 114 -> socket:[3239321]
lrwx------ 1 root root 64 Mar 12 20:16 115 -> socket:[3239503]
lrwx------ 1 root root 64 Mar 12 20:16 116 -> socket:[3239643]
lrwx------ 1 root root 64 Mar 12 20:16 117 -> socket:[3238846]
...
```