### PR TITLE
Add function to return the V2 Manifest Digest

### DIFF
--- a/registry/manifest.go
+++ b/registry/manifest.go
@@ -83,6 +83,29 @@ func (registry *Registry) ManifestDigest(repository, reference string) (digest.D
 	return digest.Parse(resp.Header.Get("Docker-Content-Digest"))
 }
 
+// ManifestV2Digest returns the 'Docker-Content-Digest' field of the header when making a
+// request to the v2 manifest.
+func (registry *Registry) ManifestV2Digest(repository, reference string) (digest.Digest, error) {
+	url := registry.url("/v2/%s/manifests/%s", repository, reference)
+	registry.Logf("registry.manifest.head url=%s repository=%s reference=%s", url, repository, reference)
+
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Accept", manifestV2.MediaTypeManifest)
+	resp, err := registry.Client.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return "", err
+	}
+
+	return digest.Parse(resp.Header.Get("Docker-Content-Digest"))
+}
+
 func (registry *Registry) DeleteManifest(repository string, digest digest.Digest) error {
 	url := registry.url("/v2/%s/manifests/%s", repository, digest)
 	registry.Logf("registry.manifest.delete url=%s repository=%s reference=%s", url, repository, digest)


### PR DESCRIPTION
This can be different than the digest that is returned if the "Accept:"
field is left out the of the request header, so include a new function
which ensures that we are getting the HEAD of a V2 manifest.