### PR TITLE
registry.new() support the log function as argument

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -38,10 +38,10 @@ type Registry struct {
  * This passes http.DefaultTransport to WrapTransport when creating the
  * http.Client.
  */
-func New(registryUrl, username, password string) (*Registry, error) {
+func New(registryUrl, username, password string, log LogfCallback) (*Registry, error) {
 	transport := http.DefaultTransport
 
-	return newFromTransport(registryUrl, username, password, transport, Log)
+	return newFromTransport(registryUrl, username, password, transport, log)
 }
 
 /*


### PR DESCRIPTION
now you can call 
`hub, err := registry.New(*registryURL, *username, *password, log.Infof)`
so all the logs will go through your favorit logger, like logrus.
Ex code : 

```
func main() {
	log.Out = os.Stdout
	log.Formatter = new(logrus.JSONFormatter)
	log.Level = logrus.DebugLevel

	flag.Parse()
	hub, err := registry.New(*registryURL, *username, *password, log.Infof)
	if err != nil {
		log.Fatalf("error connecting to hub, %v", err)
	}
...
```

Ypu can switch `log.Level = logrus.DebugLevel` to `log.Level = logrus.WarnLevel` to disable logging