### PR TITLE
Accept v1+prettyjws manifests in HTTP client

### DIFF
--- a/registry/manifest.go
+++ b/registry/manifest.go
@@ -20,6 +20,7 @@ func (registry *Registry) Manifest(repository, reference string) (*manifestV1.Si
 	}
 
 	req.Header.Set("Accept", manifestV1.MediaTypeManifest)
+	req.Header.Add("Accept", manifestV1.MediaTypeSignedManifest)
 	resp, err := registry.Client.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Example manifest: https://gcr.io/v2/google_containers/redis/manifests/e2e (image: k8s.gcr.io/redis:e2e). Content type in the HTTP response is set to `application/vnd.docker.distribution.manifest.v1+prettyjws`.