### PR TITLE
Fix UploadBlob() in case of token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ API](http://docs.docker.com/registry/spec/api/), for Go applications.
 ```go
 import (
     "github.com/heroku/docker-registry-client/registry"
-    "github.com/docker/distribution/digest"
+    digest "github.com/opencontainers/go-digest"
     "github.com/docker/distribution/manifest"
     "github.com/docker/libtrust"
 )
@@ -120,8 +120,8 @@ if err != nil {
     // …
 }
 if !exists {
-    stream := …
-    hub.UploadBlob("example/repo", digest, stream)
+    stream := bytes.NewBuffer(...)
+    hub.UploadBlob("example/repo", digest, stream, nil)
 }
 ```
 


### PR DESCRIPTION
Fixes issue https://github.com/heroku/docker-registry-client/issues/8.
As explained in the issue, UploadBlob() is not working properly in case of token authentication. More precisely it cannot resend the request after the 401 Unauthorized response, because the Body (content reader) is not reusable.