### PR TITLE
fix memory leak

### DIFF
--- a/registry/tokentransport.go
+++ b/registry/tokentransport.go
@@ -19,6 +19,7 @@ func (t *TokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return resp, err
 	}
 	if authService := isTokenDemand(resp); authService != nil {
+		resp.Body.Close()
 		resp, err = t.authAndRetry(authService, req)
 	}
 	return resp, err


### PR DESCRIPTION
close old resp.Body before request new token