### PR TITLE
Accepting tokens from "access_token"-field

### DIFF
--- a/registry/tokentransport.go
+++ b/registry/tokentransport.go
@@ -27,6 +27,7 @@ func (t *TokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 type authToken struct {
 	Token string `json:"token"`
+	AccessToken string `json:"access_token"`
 }
 
 func (t *TokenTransport) authAndRetry(authService *authService, req *http.Request) (*http.Response, error) {
@@ -66,7 +67,11 @@ func (t *TokenTransport) auth(authService *authService) (string, *http.Response,
 		return "", nil, err
 	}
 
-	return authToken.Token, nil, nil
+	if authToken.Token == "" {
+		return authToken.AccessToken, nil, nil
+	} else {
+		return authToken.Token, nil, nil
+	}
 }
 
 func (t *TokenTransport) retry(req *http.Request, token string) (*http.Response, error) {


### PR DESCRIPTION
For compatibility with OAuth 2.0, token under the name access_token should also be accepted. More info https://docs.docker.com/registry/spec/auth/token/#token-response-fields