### PR TITLE
Fix golangci linter deprecation warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,19 +8,18 @@ linters:
   enable:
     - misspell
     - goimports
-    - golint
+    - revive
     - stylecheck
     - unconvert
     - dupl
     - gosec
-    - scopelint
+    - exportloopref
     - nakedret
     - gochecknoinits
     - goconst
     - gocritic
     - gocyclo
     - lll
-    - maligned
     - prealloc
     - unparam
     - errcheck


### PR DESCRIPTION
Fixes the following warnings:

```
~/C/o/docker-registry-client ❯❯❯ golangci-lint run                                                                                                      master
WARN [runner] The linter 'maligned' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.  Replaced by govet 'fieldalignment'.
WARN [runner] The linter 'scopelint' is deprecated (since v1.39.0) due to: The repository of the linter has been deprecated by the owner.  Replaced by exportloopref.
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.
```